### PR TITLE
Allow update or insert of list members

### DIFF
--- a/components/Signup.php
+++ b/components/Signup.php
@@ -71,7 +71,7 @@ class Signup extends ComponentBase
             $subscriptionData['merge_fields'] = $data['merge'];
         }
 
-        $result = $MailChimp->post("lists/".$this->property('list')."/members", $subscriptionData);
+        $result = $MailChimp->put("lists/".$this->property('list')."/members", $subscriptionData);
 
         if (!$MailChimp->success()) {
             $this->page['error'] = $MailChimp->getLastError();

--- a/components/Signup.php
+++ b/components/Signup.php
@@ -73,7 +73,7 @@ class Signup extends ComponentBase
 
         $subscriber_hash = $MailChimp->subscriberHash(post('email'));
 
-        $result = $MailChimp->put("lists/".$this->property('list')."/members/" . $subscriber_hash, $subscriptionData);
+        $result = $MailChimp->put("lists/".$this->property('list')."/members/".$subscriber_hash, $subscriptionData);
 
         if (!$MailChimp->success()) {
             $this->page['error'] = $MailChimp->getLastError();

--- a/components/Signup.php
+++ b/components/Signup.php
@@ -71,7 +71,9 @@ class Signup extends ComponentBase
             $subscriptionData['merge_fields'] = $data['merge'];
         }
 
-        $result = $MailChimp->put("lists/".$this->property('list')."/members", $subscriptionData);
+		$subscriber_hash = $MailChimp->subscriberHash(post('email'));
+
+        $result = $MailChimp->put("lists/".$this->property('list')."/members/" . $subscriber_hash, $subscriptionData);
 
         if (!$MailChimp->success()) {
             $this->page['error'] = $MailChimp->getLastError();

--- a/components/Signup.php
+++ b/components/Signup.php
@@ -71,7 +71,7 @@ class Signup extends ComponentBase
             $subscriptionData['merge_fields'] = $data['merge'];
         }
 
-		$subscriber_hash = $MailChimp->subscriberHash(post('email'));
+        $subscriber_hash = $MailChimp->subscriberHash(post('email'));
 
         $result = $MailChimp->put("lists/".$this->property('list')."/members/" . $subscriber_hash, $subscriptionData);
 


### PR DESCRIPTION
The existing plugin version returns an error from Mailchimp if the email address is already subscribed. This change instead calls the PUT API endpoint, which will either insert or update the member.