### PR TITLE
Added functionality to tag user on signup

### DIFF
--- a/components/Signup.php
+++ b/components/Signup.php
@@ -64,6 +64,7 @@ class Signup extends ComponentBase
 
         $subscriptionData = [
             'email_address' => post('email'),
+            'tags'          => post('tags', []),
             'status'        => $this->property('confirm') ? 'pending' : 'subscribed',
         ];
 


### PR DESCRIPTION
Sometimes there is a need to tag users, with this small fix we can send a 'tags' with request to Mailchimp.
It can be done by adding hidden input in form view.