### PR TITLE
Returning result

### DIFF
--- a/components/Signup.php
+++ b/components/Signup.php
@@ -77,5 +77,7 @@ class Signup extends ComponentBase
         if (!$MailChimp->success()) {
             $this->page['error'] = $MailChimp->getLastError();
         }
+
+        return $result;
     }
 }


### PR DESCRIPTION
This fix allows to retrieve the result of onSignup() function in order to easily handle the different scenarios in front side, by accessing information like the subscription status.